### PR TITLE
fix(codegen): resolve type generation failure due to multiple Zod ins…

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
         "commander": "^14.0.1",
         "fast-glob": "^3.3.3",
         "reflect-metadata": "^0.2.2",
-        "typeorm": "^0.3.26",
-        "zod": "^3.25.76"
+        "typeorm": "^0.3.26"
+    },
+    "peerDependencies": {
+        "zod": "^3.20.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.2.4",
@@ -68,7 +70,8 @@
         "lefthook": "^1.13.1",
         "release-it": "^19.0.5",
         "tsup": "^8.5.0",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "zod": "^3.25.76"
     },
     "engines": {
         "bun": ">=1.0.0"


### PR DESCRIPTION
…tances

Fixed critical issue where codegen was generating 'any' for all types instead of proper TypeScript types. The root cause was multiple Zod instances causing instanceof checks to fail.

Changes:
- Moved Zod from dependencies to peerDependencies to ensure single instance
- Replaced instanceof checks with _def.typeName checks to work across Zod instances
- Created ZodInternal interface to properly type Zod's internal structure
- Fixed duplicate type unions (e.g., "| undefined | null | undefined | null")
- Optimized optional property handling to avoid redundant "| undefined" when "?" is present
- Removed all any type assertions in favor of proper typed interfaces

BREAKING CHANGE: Zod is now a peer dependency. Users must have zod@^3.20.0 installed in their project.

Before: Generated types were all 'any'
After: Generates proper types like "bio?: string | null" and "id?: string"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted Zod dependency setup to rely on a peer Zod at runtime and include a dev Zod for tooling.

* **Improvements**
  * Broader, more accurate type generation for many Zod schema constructs and nested scenarios.
  * Added aggregated generated schemas and validation helpers for entities.
  * Added non-silent debug logging during schema/type generation to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->